### PR TITLE
refactor: rename status "Sob controle" to "Não preciso"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Para executar o frontend do aplicativo em seu ambiente local, siga os passos aba
    ```
 4. Inicie o servidor de desenvolvimento:
    ```
-   npm start
+   npm run dev
    ```
    O app estará disponível em `http://localhost:3000`.
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,7 +12,7 @@ function cn(...inputs: ClassValue[]) {
 function variantStatusPriority(priority: SupplyPriority) {
   if (priority === SupplyPriority.Needing) return 'danger';
   if (priority === SupplyPriority.Urgent) return 'warn';
-  if (priority === SupplyPriority.UnderControl) return 'alert';
+  if (priority === SupplyPriority.NotNeeded) return 'alert';
   if (priority === SupplyPriority.Remaining) return 'success';
 }
 
@@ -22,7 +22,7 @@ function variantStatusPriority(priority: SupplyPriority) {
 const colorStatusPriority = (priority: SupplyPriority) => {
   if (priority === SupplyPriority.Needing) return 'bg-[#f69f9d]';
   if (priority === SupplyPriority.Urgent) return 'bg-[#f8b993]';
-  if (priority === SupplyPriority.UnderControl) return 'bg-[#f9cf8d]';
+  if (priority === SupplyPriority.NotNeeded) return 'bg-[#f9cf8d]';
   if (priority === SupplyPriority.Remaining) return 'bg-[#63bc43]';
 };
 
@@ -32,7 +32,7 @@ const colorStatusPriority = (priority: SupplyPriority) => {
 function nameStatusPriority(priority: SupplyPriority) {
   if (priority === SupplyPriority.Needing) return 'Precisa urgentimente';
   if (priority === SupplyPriority.Urgent) return 'Precisa';
-  if (priority === SupplyPriority.UnderControl) return 'Sob-controle';
+  if (priority === SupplyPriority.NotNeeded) return 'Não preciso';
   if (priority === SupplyPriority.Remaining) return 'Disponível para doação';
 }
 
@@ -60,10 +60,10 @@ function getAvailabilityProps(
 
 function getSupplyPriorityProps(priority: SupplyPriority) {
   switch (priority) {
-    case SupplyPriority.UnderControl:
+    case SupplyPriority.NotNeeded:
       return {
-        label: 'Sob controle',
-        className: 'bg-light-yellow',
+        label: 'Não preciso',
+        className: 'bg-gray-200',
       };
     case SupplyPriority.Remaining:
       return {

--- a/src/pages/CreateSupply/CreateSupply.tsx
+++ b/src/pages/CreateSupply/CreateSupply.tsx
@@ -37,7 +37,7 @@ const CreateSupply = () => {
       name: '',
       supplyCategoryId: supplyCategories?.at(0)?.id ?? '-1',
       shelterId,
-      priority: SupplyPriority.UnderControl,
+      priority: SupplyPriority.NotNeeded,
     },
     enableReinitialize: true,
     validateOnBlur: false,
@@ -151,7 +151,7 @@ const CreateSupply = () => {
                     SupplyPriority.Urgent,
                     SupplyPriority.Needing,
                     SupplyPriority.Remaining,
-                    SupplyPriority.UnderControl,
+                    SupplyPriority.NotNeeded,
                   ].map((priority) => {
                     const { className, label } =
                       getSupplyPriorityProps(priority);

--- a/src/pages/EditShelterSupply/EditShelterSupply.tsx
+++ b/src/pages/EditShelterSupply/EditShelterSupply.tsx
@@ -59,7 +59,7 @@ const EditShelterSupply = () => {
       console.log('Item: ', item);
       setModalOpened(true);
       setModalData({
-        value: `${item.priority ?? SupplyPriority.UnderControl}`,
+        value: `${item.priority ?? SupplyPriority.NotNeeded}`,
         onSave: (v) => {
           const isNewSupply = item.priority === undefined;
           setLoadingSave(true);
@@ -126,12 +126,12 @@ const EditShelterSupply = () => {
               value: `${SupplyPriority.Needing}`,
             },
             {
-              label: 'Sob controle',
-              value: `${SupplyPriority.UnderControl}`,
-            },
-            {
               label: 'Disponível para doação',
               value: `${SupplyPriority.Remaining}`,
+            },
+            {
+              label: 'Remover item',
+              value: `${SupplyPriority.NotNeeded}`,
             },
           ]}
           isSubmitting={loadingSave}

--- a/src/pages/EditShelterSupply/components/SupplyRow/SupplyRow.tsx
+++ b/src/pages/EditShelterSupply/components/SupplyRow/SupplyRow.tsx
@@ -13,7 +13,7 @@ const SupplyRow = (props: ISupplyRowProps) => {
           <SupplyRowInfo
             key={idy}
             name={item.name}
-            priority={item.priority ?? SupplyPriority.UnderControl}
+            priority={item.priority ?? SupplyPriority.NotNeeded}
             onClick={() => (onClick ? onClick(item) : undefined)}
           />
         ))}

--- a/src/pages/Shelter/Shelter.tsx
+++ b/src/pages/Shelter/Shelter.tsx
@@ -20,7 +20,7 @@ const Shelter = () => {
 
   const shelterCategories: IShelterCategoryItemsProps[] = useMemo(() => {
     const grouped = group(shelters?.shelterSupplies ?? [], 'priority');
-    delete grouped[SupplyPriority.UnderControl];
+    delete grouped[SupplyPriority.NotNeeded];
     return Object.entries(grouped)
       .sort(([a], [b]) => (+a > +b ? -1 : 1))
       .map(([key, values]) => ({

--- a/src/pages/Shelter/components/ShelterCategoryItems/ShelterCategoryItems.tsx
+++ b/src/pages/Shelter/components/ShelterCategoryItems/ShelterCategoryItems.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { SupplyPriority } from '@/service/supply/types';
 
 const ShelterCategoryItems = (props: IShelterCategoryItemsProps) => {
-  const { priority = SupplyPriority.UnderControl, tags } = props;
+  const { priority = SupplyPriority.NotNeeded, tags } = props;
   const [opened, setOpened] = useState<boolean>(false);
   const maxVisibleTags: number = 10;
   const visibleTags = useMemo(

--- a/src/service/supply/types.ts
+++ b/src/service/supply/types.ts
@@ -1,5 +1,5 @@
 export enum SupplyPriority {
-  UnderControl = 0,
+  NotNeeded = 0,
   Remaining = 1,
   Needing = 10,
   Urgent = 100,


### PR DESCRIPTION
## O que consta nesse PR:
- Renome do status "Sob controle" para "Não preciso"
- Renome do botão "Sob controle" para "Remover item" na alteração de status; botão movido para último da lista
- Alteração de cor do status "Não preciso" para cinza, conforme acordado com designer pelo Discord (canal #frontend) 
- Alteração no README para constar comando correto para rodar o projeto

## Evidências de Implementação:

### Listagem de Itens
<img width="1468" alt="image" src="https://github.com/SOS-RS/frontend/assets/19597184/d784c04b-94c2-4163-a922-e70c5c16b46b">

### Editando um Item
<img width="1468" alt="image" src="https://github.com/SOS-RS/frontend/assets/19597184/c59c0c72-f9cc-4f03-951f-82e82cfc16b9">

### Criando um Item
<img width="1468" alt="image" src="https://github.com/SOS-RS/frontend/assets/19597184/7a8a4be9-3df9-4e5b-8932-95ad7e3cd0bc">

