### PR TITLE
adds accordion to supply selection

### DIFF
--- a/src/pages/EditShelterSupply/components/SupplyRow/SupplyRow.tsx
+++ b/src/pages/EditShelterSupply/components/SupplyRow/SupplyRow.tsx
@@ -1,14 +1,21 @@
 import { SupplyPriority } from '@/service/supply/types';
 import { SupplyRowInfo } from '../SupplyRowInfo';
 import { ISupplyRowProps } from './types';
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 
 const SupplyRow = (props: ISupplyRowProps) => {
   const { name, items, onClick } = props;
 
   return (
-    <div className="gap-4 flex flex-col pb-6">
-      <h3 className="font-semibold text-lg">{name}</h3>
-      <div className="flex flex-col">
+    <AccordionItem value={name}>
+      <AccordionTrigger>
+        <h3 className="text-lg font-semibold">{name}</h3>
+      </AccordionTrigger>
+      <AccordionContent className="flex flex-col">
         {items.map((item, idy) => (
           <SupplyRowInfo
             key={idy}
@@ -17,8 +24,8 @@ const SupplyRow = (props: ISupplyRowProps) => {
             onClick={() => (onClick ? onClick(item) : undefined)}
           />
         ))}
-      </div>
-    </div>
+      </AccordionContent>
+    </AccordionItem>
   );
 };
 

--- a/src/pages/EditShelterSupply/components/SupplyRowInfo/SupplyRowInfo.tsx
+++ b/src/pages/EditShelterSupply/components/SupplyRowInfo/SupplyRowInfo.tsx
@@ -15,12 +15,12 @@ const SupplyRowInfo = (props: ISupplyRowInfoProps) => {
   return (
     <div
       onClick={onClick}
-      className="flex w-full justify-between content-end border-b-[1px] border-b-border py-4 hover:cursor-pointer hover:bg-slate-50 px-1 rounded-sm"
+      className="flex w-full justify-between content-end border-b-[1px] border-b-border [&:last-of-type]:border-none py-4 hover:cursor-pointer hover:bg-slate-50 px-1 rounded-sm"
     >
       <h2 className="font-medium">{name}</h2>
-      <div className="flex justify-end items-center gap-2">
+      <div className="flex items-center justify-end gap-2">
         <CircleStatus className={className} />
-        <p className="text-muted-foreground text-nowrap pl-1">{label}</p>
+        <p className="pl-1 text-muted-foreground text-nowrap">{label}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
A mudança é puramente visual pra facilitar a usabilidade na seleção de items de necessidade

Hoje ela é uma lista corrida com todos os grupos e items dispostos na página

![image](https://github.com/SOS-RS/frontend/assets/75024157/a2840426-d436-4369-85c1-e78fd1f4168c)

Eu implementei a visualização com Accordion, facilitando a visualização dos tópicos existentes

![image](https://github.com/SOS-RS/frontend/assets/75024157/8f082b63-8008-4c40-8afc-e64cdae98fea)
