### PR TITLE
fix: fix label synchronization with option in the "DialogSelector" component

### DIFF
--- a/src/components/DialogSelector/DialogSelector.tsx
+++ b/src/components/DialogSelector/DialogSelector.tsx
@@ -40,8 +40,8 @@ const DialogSelector = (props: IDialogSelectorProps) => {
           >
             {options.map((option, idx) => (
               <div key={idx} className="flex items-center space-x-2 py-2">
-                <RadioGroupItem value={option.value} id="r1" />
-                <Label htmlFor="r1">{option.label}</Label>
+                <RadioGroupItem value={option.value} id={option.value} />
+                <Label htmlFor={option.value}>{option.label}</Label>
               </div>
             ))}
           </RadioGroup>


### PR DESCRIPTION
## Descrição problema
 - No componente "DialogSelector" quando clica na label de alguma opção, a primeira opção é selecionada

![test](https://github.com/SOS-RS/frontend/assets/92539348/3dd1e65e-4edd-4ea1-9ec4-974052867068)

## Solução
 - Foi ajustado a prop `id` do "RadioGroupItem" e a prop `htmlFor` do Label, ambos para usarem o `value` da `option`
 
 
![fix](https://github.com/SOS-RS/frontend/assets/92539348/8f542d10-1f50-4a7f-b831-e540e89b9ee8)
