### PR TITLE
feat: adds searchable input to create new supplies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@ariakit/react": "^0.4.6",
         "@hookform/resolvers": "^3.3.4",
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-checkbox": "^1.0.4",
@@ -76,6 +77,41 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ariakit/core": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.6.tgz",
+      "integrity": "sha512-L2WIZZlxDs611m3YLSv2xvJyQrkkVQJlxn8Y4DlI1G65VLTEH7hysw3RYUNdXsl0gP6S20id3zBMJCHT9BCRcg=="
+    },
+    "node_modules/@ariakit/react": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.6.tgz",
+      "integrity": "sha512-7lZQew9n+nxswgJ5aL87xo42I+t3A8gWzaxIIZY+c58SLCASh1IdDkGLhGPcyhmXWRIjs/8L1h6cMbRMEBrtJQ==",
+      "dependencies": {
+        "@ariakit/react-core": "0.4.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ariakit"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-core": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.6.tgz",
+      "integrity": "sha512-2Ca327IzSOxQEd3gEr59JJj0y8fXDMLYd+948wyOzIsk2/yoTnA4+R7Vhs361w3KzOjBQM44KmnNL7ckBMtT0w==",
+      "dependencies": {
+        "@ariakit/core": "0.4.6",
+        "@floating-ui/dom": "^1.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5567,6 +5603,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ariakit/react": "^0.4.6",
     "@hookform/resolvers": "^3.3.4",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.0.4",

--- a/src/components/SearchableInput/index.tsx
+++ b/src/components/SearchableInput/index.tsx
@@ -1,0 +1,77 @@
+import {
+  useCallback,
+  useState,
+  forwardRef,
+  InputHTMLAttributes,
+  ChangeEvent
+} from "react"
+import * as Ariakit from "@ariakit/react"
+
+import { cn } from "@/lib/utils"
+
+import "./style.css"
+import { useThrottle } from "@/hooks"
+
+export interface SearchableInputProps
+  extends InputHTMLAttributes<HTMLInputElement> {
+    label?: string
+    data: { id: string, value: string, label: string } []
+    onClickSuggestion: (item: SearchableInputProps["data"][number]) => void
+    errorMessage?: string
+    throttle: number
+  }
+
+const SearchableInput = forwardRef<HTMLInputElement, SearchableInputProps>(
+  ({ data, label, throttle, errorMessage, onClickSuggestion, className, type, ...props }, ref) => {
+    const [filteredData, setFilteredData] = useState<SearchableInputProps["data"]>([])
+
+    const [, setSearch] = useThrottle<string>(
+      {
+        throttle,
+        callback: (v) => {
+          if (v) {
+            setFilteredData(
+              data.filter((item) =>
+                item.value.toLowerCase().includes(v.toLowerCase())
+              )
+            );
+          } else setFilteredData([]);
+        },
+      },
+      [data]
+    );
+
+    const handleChange = useCallback((event: ChangeEvent<HTMLInputElement> ) => {
+      props?.onChange?.(event)
+      setSearch(event.target.value)
+    }, [props, setSearch])
+
+    return (
+      <Ariakit.ComboboxProvider>
+        <div className="flex flex-col">
+          {label && <label className="text-muted-foreground">{label}</label>}
+          <Ariakit.Combobox ref={ref} type={type} className={cn(className, "combobox", "w-full")} {...props} onChange={handleChange}/>
+          {errorMessage &&  <p className={'text-red-600 text-sm'}>{errorMessage}</p>}
+        </div>
+        {filteredData.length ? (
+          <Ariakit.ComboboxPopover gutter={4} sameWidth className="popover w-full">
+            {filteredData.map((item) => (
+              <Ariakit.ComboboxItem
+                key={item.value}
+                onClick={() => onClickSuggestion(item)}
+                className="combobox-item hover:cursor-pointer"
+                value={item.value}>
+                {item.label}
+              </Ariakit.ComboboxItem>
+            ))}
+          </Ariakit.ComboboxPopover> 
+        ) : null}
+      </Ariakit.ComboboxProvider>
+    )
+  }
+)
+SearchableInput.displayName = "SearchableInput"
+
+export { SearchableInput }
+
+/* reference: https://ariakit.org/components/combobox */

--- a/src/components/SearchableInput/style.css
+++ b/src/components/SearchableInput/style.css
@@ -1,0 +1,124 @@
+.label {
+  width: 250px;
+  padding-left: 1rem;
+  padding-bottom: 0.5rem;
+}
+
+.combobox {
+  height: 2.5rem;
+  width: 250px;
+  border-radius: 0.375rem;
+  border-style: none;
+  background-color: white;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: black;
+  outline-width: 1px;
+  outline-offset: -1px;
+  outline-color: hsl(204 100% 40%);
+  box-shadow:
+    inset 0 0 0 1px rgba(0 0 0/0.15),
+    inset 0 2px 5px 0 rgba(0 0 0/0.08);
+}
+
+.combobox::placeholder {
+  color: rgb(0 0 0 / 0.6);
+}
+
+.combobox:hover {
+  background-color: hsl(204 20% 99%);
+}
+
+.combobox[data-focus-visible] {
+  outline-style: solid;
+}
+
+.combobox[data-active-item] {
+  outline-width: 2px;
+}
+
+.combobox:where(.dark, .dark *) {
+  background-color: hsl(204 4% 8%);
+  color: white;
+  box-shadow:
+    inset 0 0 0 1px rgba(255 255 255/0.15),
+    inset 0 -1px 0 0 rgba(255 255 255/0.05),
+    inset 0 2px 5px 0 rgba(0 0 0/0.15);
+}
+
+.combobox:where(.dark, .dark *)::placeholder {
+  color: rgb(255 255 255 / 46%);
+}
+
+.combobox:hover:where(.dark, .dark *) {
+  background-color: hsl(204 4% 6%);
+}
+
+.popover {
+  position: relative;
+  z-index: 50;
+  display: flex;
+  max-height: min(var(--popover-available-height, 300px), 300px);
+  flex-direction: column;
+  overflow: auto;
+  overscroll-behavior: contain;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-style: solid;
+  border-color: hsl(204 20% 88%);
+  background-color: white;
+  padding: 0.5rem;
+  color: black;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.1),
+    0 4px 6px -4px rgb(0 0 0 / 0.1);
+}
+
+.popover:where(.dark, .dark *) {
+  border-color: hsl(204 4% 24%);
+  background-color: hsl(204 4% 16%);
+  color: white;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.25),
+    0 4px 6px -4px rgb(0 0 0 / 0.1);
+}
+
+.combobox-item {
+  display: flex;
+  cursor: default;
+  scroll-margin: 0.5rem;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  padding: 0.5rem;
+  outline: none !important;
+}
+
+.combobox-item:hover {
+  background-color: hsl(204 100% 80% / 0.4);
+}
+
+.combobox-item[data-active-item] {
+  background-color: hsl(204 100% 40%);
+  color: white;
+}
+
+.combobox-item:active,
+.combobox-item[data-active] {
+  padding-top: 9px;
+  padding-bottom: 7px;
+}
+
+.combobox-item:hover:where(.dark, .dark *) {
+  background-color: hsl(204 100% 40% / 0.25);
+}
+
+.combobox-item:where(.dark, .dark *)[data-active-item] {
+  background-color: hsl(204 100% 40%);
+}
+
+/* reference: https://ariakit.org/components/combobox */

--- a/src/pages/CreateSupply/CreateSupply.tsx
+++ b/src/pages/CreateSupply/CreateSupply.tsx
@@ -3,10 +3,10 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 
-import { CircleStatus, Header, LoadingScreen, TextField } from '@/components';
+import { CircleStatus, Header, LoadingScreen } from '@/components';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
-import { useSupplyCategories } from '@/hooks';
+import { useSupplies, useSupplyCategories } from '@/hooks';
 import {
   Select,
   SelectContent,
@@ -18,13 +18,15 @@ import { ICreateSupply, SupplyPriority } from '@/service/supply/types';
 import { getSupplyPriorityProps } from '@/lib/utils';
 import { ShelterSupplyServices, SupplyServices } from '@/service';
 import { ICreateShelterSupply } from '@/service/shelterSupply/types';
+import { SearchableInput } from '@/components/SearchableInput';
 
 const CreateSupply = () => {
   const navigate = useNavigate();
   const { shelterId = '-1' } = useParams();
   const { toast } = useToast();
   const { data: supplyCategories, loading } = useSupplyCategories();
-
+  const { data: supplies } = useSupplies();
+  
   const {
     errors,
     getFieldProps,
@@ -99,12 +101,20 @@ const CreateSupply = () => {
             prioridade
           </p>
           <div className="flex flex-col gap-6 w-full mt-6">
-            <TextField
-              label="Nome do item"
-              {...getFieldProps('name')}
-              error={!!errors.name}
-              helperText={errors.name}
-            />
+          <SearchableInput
+            label="Nome do item"
+            data={supplies.map((supply) => ({
+              label: supply.name,
+              value: supply.name,
+              id: supply.id
+            }))}
+            onClickSuggestion={(supply) => {
+              navigate(`/abrigo/${shelterId}/items`, { state: { supplyIdToAdd: supply.id } })
+            }}
+            {...getFieldProps('name')}
+            errorMessage={errors["name"]}
+            throttle={300}
+          />              
             <div className="flex flex-col w-full">
               <label className="text-muted-foreground">Categoria</label>
               <Select

--- a/src/pages/EditShelterSupply/EditShelterSupply.tsx
+++ b/src/pages/EditShelterSupply/EditShelterSupply.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, PlusCircle } from 'lucide-react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DialogSelector, Header, LoadingScreen, TextField } from '@/components';
@@ -16,6 +16,7 @@ import { IUseShelterDataSupply } from '@/hooks/useShelter/types';
 
 const EditShelterSupply = () => {
   const navigate = useNavigate();
+  const location = useLocation()
   const { shelterId = '-1' } = useParams();
   const { toast } = useToast();
   const { data: shelter, loading, refresh } = useShelter(shelterId);
@@ -67,6 +68,9 @@ const EditShelterSupply = () => {
           const successCallback = () => {
             setModalOpened(false);
             setModalData(null);
+            if (location.state?.supplyIdToAdd) {
+              navigate('.', { state: null });
+            }
             refresh();
           };
 
@@ -100,12 +104,30 @@ const EditShelterSupply = () => {
         },
       });
     },
-    [refresh, shelterId, toast]
+    [location.state, navigate, refresh, shelterId, toast]
   );
 
   useEffect(() => {
     setFilteredSupplies(supplies);
   }, [supplies]);
+
+  useEffect(() => {
+    const { supplyIdToAdd } = location.state ?? {}
+    
+    if (!supplyIdToAdd) return
+
+    const findShelterDataSupply = shelterSupplyData[supplyIdToAdd]
+
+    if (findShelterDataSupply && findShelterDataSupply.supply) {
+      const { supply, priority } = findShelterDataSupply
+
+      handleClickSupplyRow({
+        id: supply?.id,
+        name: supply?.name,
+        priority
+      }) 
+    }
+  }, [handleClickSupplyRow, location.state, shelterSupplyData, supplies])
 
   if (loading) return <LoadingScreen />;
 


### PR DESCRIPTION
## Overview
 - De acordo com a [tarefa](https://trello.com/c/Cn6DBstR/6-frontend-adicionar-campo-pesquis%C3%A1vel-ao-adicionar-novo-item-para-selecionar-itens-j%C3%A1-cadastrados), era necessario que o campo de entrada para cadastrar novos itens de suprimentos seja transformado em um campo pesquisável, que sugira itens já cadastrados em outros abrigos à medida que digito, para facilitar o processo de cadastro e evitar a duplicidade de itens.
 
## Implementação
![feat](https://github.com/SOS-RS/frontend/assets/92539348/c5e55d04-3e78-47ab-8a48-5dd443f31108)

## Observação
 - Fala galera, pode não ter sido um bom código mas a inteção é contribuir, sou estagiário então dêem um desconto aí hehehe