### PR TITLE
Adds subtitles at the top of the home page

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -16,6 +16,9 @@ import { Button } from '@/components/ui/button';
 import { SessionContext } from '@/contexts';
 import { Filter } from './components/Filter';
 import { IUseShelterSearchParams } from '@/hooks/useShelters/types';
+import { SupplyPriority } from '@/service/supply/types';
+import { getSupplyPriorityProps } from '@/lib/utils';
+import { Chip } from '@/components/Chip';
 
 const alertDescription =
   'Você pode consultar a lista de abrigos disponíveis. Ver e editar os itens que necessitam de doações.';
@@ -179,6 +182,22 @@ const Home = () => {
             </h1>
           </Button>
         </div>
+        <h6 className={'font-semibold text-md'}>Legenda</h6>
+        <div className="flex flex-row gap-2">
+          {Object.values(SupplyPriority)
+            .filter((value): value is number => typeof value === 'number')
+            .map((p, idx) => {
+              const { label, className } = getSupplyPriorityProps(p);
+              return (
+                <Chip
+                  key={idx}
+                  label={label}
+                  className={`${className} w-fit`}
+                />
+              );
+            })}
+        </div>
+
         <main className="flex flex-col gap-4">
           {loading ? (
             <Loader className="justify-self-center self-center w-5 h-5 animate-spin" />


### PR DESCRIPTION
Adiciona ao top da home as legendas de cores para facilitar o rápido entendimento do sistema de cores.

Da forma atual, o usuário precisa clicar no abrigo e entrar para descobrir o que cada cor significa

Ficaria assim agora: 


<img width="1105" alt="Screenshot 2024-05-10 at 10 42 21" src="https://github.com/SOS-RS/frontend/assets/8139090/88c208df-14e7-4696-a4b6-1ab9b1d9ce3f">


As legendas estão sendo renderizadas direto do Enum, então caso ele seja editado, refletirá automaticamente na home.