### PR TITLE
feat(EditShelter): collapsing categories supply in shelter edit

### DIFF
--- a/src/pages/EditShelterSupply/EditShelterSupply.tsx
+++ b/src/pages/EditShelterSupply/EditShelterSupply.tsx
@@ -191,6 +191,7 @@ const EditShelterSupply = () => {
                   key={idx}
                   name={key}
                   items={items}
+                  filtered={searchValue != ''}
                   onClick={handleClickSupplyRow}
                 />
               );

--- a/src/pages/EditShelterSupply/components/SupplyRow/SupplyRow.tsx
+++ b/src/pages/EditShelterSupply/components/SupplyRow/SupplyRow.tsx
@@ -1,15 +1,32 @@
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { SupplyPriority } from '@/service/supply/types';
 import { SupplyRowInfo } from '../SupplyRowInfo';
 import { ISupplyRowProps } from './types';
 
 const SupplyRow = (props: ISupplyRowProps) => {
-  const { name, items, onClick } = props;
+  const { name, items, filtered, onClick } = props;
+  const [opened, setOpened] = useState<boolean>(false);
+  const maxVisibleTags: number = 0;
+  const visibleSupplies = useMemo(
+    () => (opened || filtered ? items : items.slice(0, maxVisibleTags)),
+    [opened, items]
+  );
+
+  const Icon = opened || filtered ? ChevronUp : ChevronDown;
 
   return (
     <div className="gap-4 flex flex-col pb-6">
+      <div onClick={() => setOpened((v) => !v)}
+      className="flex w-full justify-between content-end border-b-[1px] border-b-border py-4 hover:cursor-pointer hover:bg-slate-50 px-1 rounded-sm"
+    >
       <h3 className="font-semibold text-lg">{name}</h3>
+      <div className="flex justify-end items-center gap-2">
+        <Icon className="h-5 w-5 stroke-blue-500" />
+      </div>
+    </div>
       <div className="flex flex-col">
-        {items.map((item, idy) => (
+        { visibleSupplies.map((item, idy) => (
           <SupplyRowInfo
             key={idy}
             name={item.name}

--- a/src/pages/EditShelterSupply/components/SupplyRow/types.ts
+++ b/src/pages/EditShelterSupply/components/SupplyRow/types.ts
@@ -3,6 +3,7 @@ import { SupplyPriority } from '@/service/supply/types';
 export interface ISupplyRowItemProps {
   id: string;
   name: string;
+  filtered: boolean;
   priority?: SupplyPriority;
 }
 
@@ -10,4 +11,5 @@ export interface ISupplyRowProps {
   name: string;
   onClick?: (item: ISupplyRowItemProps) => void;
   items: ISupplyRowItemProps[];
+  filtered: boolean;
 }


### PR DESCRIPTION
Na edição de abrigo, traz as categorias "recolhidas" para simplificar a busca por categoria, porém quando a busca é feita por texto reabre todas
<img width="1332" alt="Captura de Tela 2024-05-10 às 17 50 23" src="https://github.com/SOS-RS/frontend/assets/15888217/b333c970-bcef-4fc5-8e99-62f396788e8b">
<img width="1339" alt="Captura de Tela 2024-05-10 às 17 50 34" src="https://github.com/SOS-RS/frontend/assets/15888217/13e6de6f-decd-4c59-bfd3-853ff1dfd220">
<img width="1270" alt="Captura de Tela 2024-05-10 às 17 50 45" src="https://github.com/SOS-RS/frontend/assets/15888217/fa32b598-d9d3-4e72-b69c-eda2ea310f70">

