### PR TITLE
fix: DialogSelector: Fix radio buttons id

### DIFF
--- a/src/components/DialogSelector/DialogSelector.tsx
+++ b/src/components/DialogSelector/DialogSelector.tsx
@@ -40,8 +40,8 @@ const DialogSelector = (props: IDialogSelectorProps) => {
           >
             {options.map((option, idx) => (
               <div key={idx} className="flex items-center space-x-2 py-2">
-                <RadioGroupItem value={option.value} id="r1" />
-                <Label htmlFor="r1">{option.label}</Label>
+                <RadioGroupItem value={option.value} id={'r' + idx} />
+                <Label htmlFor={'r' + idx}>{option.label}</Label>
               </div>
             ))}
           </RadioGroup>


### PR DESCRIPTION
Ao clicar no label de qualquer radio button do DialogSelector, o primeiro radio button da lista sempre é selecionado.

![image](https://github.com/SOS-RS/frontend/assets/604678/ef3165c5-d379-4791-ad43-76fd53a597d4)

Corrige isso atribuindo o índice do item da lista ao id do radio.