### PR TITLE
Links no about usam href ao invés de window.open

### DIFF
--- a/src/components/CardAboutShelter/components/InfoRow/InfoRow.tsx
+++ b/src/components/CardAboutShelter/components/InfoRow/InfoRow.tsx
@@ -9,9 +9,8 @@ const InfoRow = React.forwardRef<HTMLDivElement, IInfoRowProps>(
     const ValueComp = !value ? (
       <Fragment />
     ) : isLink ? (
-      <a
+      <a href={`${value}`} target='_blank'
         className="text-blue-500 break-all cursor-pointer hover:underline"
-        onClick={() => window.open(value, '_blank')}
       >
         {value}
       </a>

--- a/src/components/CardAboutShelter/components/InfoRow/InfoRow.tsx
+++ b/src/components/CardAboutShelter/components/InfoRow/InfoRow.tsx
@@ -9,7 +9,7 @@ const InfoRow = React.forwardRef<HTMLDivElement, IInfoRowProps>(
     const ValueComp = !value ? (
       <Fragment />
     ) : isLink ? (
-      <a href={`${value}`} target='_blank'
+      <a href={value} target='_blank'
         className="text-blue-500 break-all cursor-pointer hover:underline"
       >
         {value}


### PR DESCRIPTION
Esse PR melhora os links no about do abrigo utilizando `href` ao invés de usar javascript via `window.open`. Melhora acessibilidade e é mais fácil de copiar o endereço.
Esse gif ilustra a diferença do antes de depois:
![chrome_MMMeXHVFlZ](https://github.com/SOS-RS/frontend/assets/10300609/4251cd08-bacf-4ff2-9da5-23f2c7307dcc)
