### PR TITLE
Open shelter address in google maps

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestHeaders, InternalAxiosRequestConfig } from 'axios';
 import { clearCache, getCacheRequestData, handleCacheResponse } from './cache';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:4000/',
+  baseURL: import.meta.env.VITE_API_URL ?? 'https://api.sos-rs.com/',
 });
 
 function handleRequestAuthToken(config: InternalAxiosRequestConfig<any>) {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestHeaders, InternalAxiosRequestConfig } from 'axios';
 import { clearCache, getCacheRequestData, handleCacheResponse } from './cache';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL ?? 'https://api.sos-rs.com/',
+  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:4000/',
 });
 
 function handleRequestAuthToken(config: InternalAxiosRequestConfig<any>) {

--- a/src/components/CardAboutShelter/CardAboutShelter.tsx
+++ b/src/components/CardAboutShelter/CardAboutShelter.tsx
@@ -80,7 +80,7 @@ const CardAboutShelter = (props: ICardAboutShelter) => {
           value={check(shelter.pix) ? `${shelter.pix}` : 'Não informado'}
         />
       </div>
-    </Card >
+    </Card>
   );
 };
 

--- a/src/components/CardAboutShelter/CardAboutShelter.tsx
+++ b/src/components/CardAboutShelter/CardAboutShelter.tsx
@@ -22,7 +22,7 @@ const CardAboutShelter = (props: ICardAboutShelter) => {
     <Card className="flex flex-col gap-2 p-4 bg-[#E8F0F8] text-sm">
       <div className="text-[#646870] font-medium">Sobre o abrigo</div>
       <div className="flex flex-col flex-wrap gap-3">
-        <InfoRow className="items-center" icon={<Home />} label={`${shelter.address}`}>
+        <InfoRow icon={<Home />} label={`${shelter.address}`}>
           <a
             href={`https://maps.google.com/?q=${encodeURI(shelter.address)}`}
             target="_blank"

--- a/src/components/CardAboutShelter/CardAboutShelter.tsx
+++ b/src/components/CardAboutShelter/CardAboutShelter.tsx
@@ -24,7 +24,7 @@ const CardAboutShelter = (props: ICardAboutShelter) => {
       <div className="flex flex-col flex-wrap gap-3">
         <InfoRow icon={<Home />} label={`${shelter.address}`}>
           <a
-            href={`https://maps.google.com/?q=${encodeURI(shelter.address)}`}
+            href={`https://maps.google.com/?q=${encodeURIComponent(shelter.address)}`}
             target="_blank"
             className="text-blue-500 break-all cursor-pointer hover:underline"
           >

--- a/src/components/CardAboutShelter/CardAboutShelter.tsx
+++ b/src/components/CardAboutShelter/CardAboutShelter.tsx
@@ -22,7 +22,15 @@ const CardAboutShelter = (props: ICardAboutShelter) => {
     <Card className="flex flex-col gap-2 p-4 bg-[#E8F0F8] text-sm">
       <div className="text-[#646870] font-medium">Sobre o abrigo</div>
       <div className="flex flex-col flex-wrap gap-3">
-        <InfoRow icon={<Home />} label={shelter.address} />
+        <InfoRow className="items-center" icon={<Home />} label={`${shelter.address}`}>
+          <a
+            href={`https://maps.google.com/?q=${encodeURI(shelter.address)}`}
+            target="_blank"
+            className="text-blue-500 break-all cursor-pointer hover:underline"
+          >
+            Abrir no Google Maps
+          </a>
+        </InfoRow>
         <InfoRow
           icon={<PawPrint />}
           label={
@@ -72,7 +80,7 @@ const CardAboutShelter = (props: ICardAboutShelter) => {
           value={check(shelter.pix) ? `${shelter.pix}` : 'Não informado'}
         />
       </div>
-    </Card>
+    </Card >
   );
 };
 

--- a/src/components/CardAboutShelter/CardAboutShelter.tsx
+++ b/src/components/CardAboutShelter/CardAboutShelter.tsx
@@ -28,7 +28,7 @@ const CardAboutShelter = (props: ICardAboutShelter) => {
             target="_blank"
             className="text-blue-500 break-all cursor-pointer hover:underline"
           >
-            Abrir no Google Maps
+            Ver no Google Maps
           </a>
         </InfoRow>
         <InfoRow

--- a/src/components/CardAboutShelter/components/InfoRow/InfoRow.tsx
+++ b/src/components/CardAboutShelter/components/InfoRow/InfoRow.tsx
@@ -4,7 +4,7 @@ import { IInfoRowProps } from './types';
 
 const InfoRow = React.forwardRef<HTMLDivElement, IInfoRowProps>(
   (props, ref) => {
-    const { icon, label, value, className = '', ...rest } = props;
+    const { icon, label, value, className = '', children, ...rest } = props;
     const isLink = value?.startsWith('http');
     const ValueComp = !value ? (
       <Fragment />
@@ -37,6 +37,11 @@ const InfoRow = React.forwardRef<HTMLDivElement, IInfoRowProps>(
             {label}
           </span>
           <span className="md:flex">{ValueComp}</span>
+          {children ? (
+            children
+          ) : (
+            null
+          )}
         </div>
       </div>
     );

--- a/src/components/CardAboutShelter/components/InfoRow/InfoRow.tsx
+++ b/src/components/CardAboutShelter/components/InfoRow/InfoRow.tsx
@@ -37,11 +37,7 @@ const InfoRow = React.forwardRef<HTMLDivElement, IInfoRowProps>(
             {label}
           </span>
           <span className="md:flex">{ValueComp}</span>
-          {children ? (
-            children
-          ) : (
-            null
-          )}
+          {children}
         </div>
       </div>
     );


### PR DESCRIPTION
Adds a button right next to the shelter address to open it in Google Maps
The `InfoRow` component was modified to accept children in order to render this link.

![chrome_wbBFKfzGuA](https://github.com/SOS-RS/frontend/assets/10300609/8549534b-96e3-4441-800f-7e5c94cd03bf)


