### PR TITLE
Fix: desalinhamento do badge/botão em títulos grandes

### DIFF
--- a/src/pages/Home/components/ShelterListItem/ShelterListItem.tsx
+++ b/src/pages/Home/components/ShelterListItem/ShelterListItem.tsx
@@ -43,23 +43,29 @@ const ShelterListItem = (props: IShelterListItemProps) => {
 
   return (
     <div className="flex flex-col p-4 w-full border-2 border-border rounded-md gap-1 relative">
-      <Button size="sm" variant="ghost" className="absolute top-4 right-4">
-        <ChevronRight
-          className="h-5 w-5"
+      <div className="inline-flex justify-between">
+        <div
+          className="flex flex-row items-center gap-1"
           onClick={() => navigate(`/abrigo/${data.id}`)}
-        />
-      </Button>
-      <div
-        className="flex items-center gap-1"
-        onClick={() => navigate(`/abrigo/${data.id}`)}
-      >
-        <h3
-          className="font-semibold text-lg  hover:cursor-pointer hover:text-slate-500"
-          onClick={onClick}
         >
-          {data.name}
-        </h3>
-        {data.verified && <VerifiedBadge />}
+          <h3
+            className="font-semibold text-lg h-full hover:cursor-pointer hover:text-slate-500"
+            onClick={onClick}
+          >
+            {data.name}
+          </h3>
+          {data.verified && (
+            <div className="h-full pt-1">
+              <VerifiedBadge />
+            </div>
+          )}
+        </div>
+        <Button size="sm" variant="ghost" className="">
+          <ChevronRight
+            className="h-5 w-5"
+            onClick={() => navigate(`/abrigo/${data.id}`)}
+          />
+        </Button>
       </div>
       <h6 className={cn('font-semibold text-md', availabilityClassName)}>
         {availability}


### PR DESCRIPTION
### Problema
O título do abrigo quando possui um tamanho grande, faz com que o badge de verificado desalinhe e fique abaixo do botão de ver mais informações.

### Solução
Adicionado divs específicas para encapsular os componentes e feito alterações no estilo e posicionamento.
Esta solução previne o problema em qualquer tamanho de texto, conforme pode ser visto no gif.

### Antes
![image](https://github.com/SOS-RS/frontend/assets/23422294/85179d12-4cd0-4142-aca4-98eda537f8af)

### Depois
![Screenshot from 2024-05-11 20-28-35](https://github.com/SOS-RS/frontend/assets/23422294/abf1c8c2-e5f8-4667-b419-3ce5425c6b65)

![captura-bug-text-wrap-2024-5-11](https://github.com/SOS-RS/frontend/assets/23422294/bd952a60-d6e0-4435-995d-e2dfc3381ce3)
