### PR TITLE
Somente exibir campo de Contato quando logado(staff ou user)

### DIFF
--- a/src/components/CardAboutShelter/CardAboutShelter.tsx
+++ b/src/components/CardAboutShelter/CardAboutShelter.tsx
@@ -59,13 +59,15 @@ const CardAboutShelter = (props: ICardAboutShelter) => {
               : 'Não informado'
           }
         />
-        <InfoRow
-          icon={<Smartphone />}
-          label="Contato:"
-          value={
-            check(shelter.contact) ? `${shelter.contact}` : 'Não informado'
-          }
-        />
+        {Boolean(shelter?.contact) && (
+          <InfoRow
+            icon={<Smartphone />}
+            label="Contato:"
+            value={
+              check(shelter.contact) ? `${shelter.contact}` : 'Não informado'
+            }
+          />
+        )}
         <InfoRow
           icon={<Landmark />}
           label="Chave Pix:"


### PR DESCRIPTION
## Descrição
Essa depende de uma PR do backend, mas basicamente somente vai listar a linha de contato na página de `Detalhes do abrigo` caso este seja retornado do backend(não precisando aplicar outras regras no front para tal)

## Depende
- https://github.com/SOS-RS/backend/pull/77

## Testes
É preciso fazer uns testes já que modifica alguns pontos e pode quebrar outros. Apesar de testar localmente e não ter quebrado nada os casos recomendados(mais impactados) foram:
 - (Logado) Testar no frontend detalhe de um abrigo: deve aparecer o contato
 - (Não Logado) Testar no frontend detalhe de um abrigo: **não** deve aparecer o contato