### PR TITLE
Atualização do atributo `id` para elementos do RadioGroupItem

### DIFF
--- a/src/components/DialogSelector/DialogSelector.tsx
+++ b/src/components/DialogSelector/DialogSelector.tsx
@@ -40,8 +40,8 @@ const DialogSelector = (props: IDialogSelectorProps) => {
           >
             {options.map((option, idx) => (
               <div key={idx} className="flex items-center space-x-2 py-2">
-                <RadioGroupItem value={option.value} id="r1" />
-                <Label htmlFor="r1">{option.label}</Label>
+                <RadioGroupItem value={option.value} id={option.value} />
+                <Label htmlFor={option.value}>{option.label}</Label>
               </div>
             ))}
           </RadioGroup>


### PR DESCRIPTION
## Descrição

Esta alteração visa melhorar a usabilidade e a acessibilidade dos elementos de entrada de dados em nossa aplicação, especificamente no componente de grupo de botões de rádio.

## Mudanças

- **Atributo `id` dinâmico**: Atualizei o atributo `id` dos elementos `<RadioGroupItem>` para serem dinâmicos e únicos, utilizando o valor da propriedade `value` de cada opção. Anteriormente, estava definido como "r1" fixo para todos os elementos.
  
  - Agora, o atributo `id` de cada `<RadioGroupItem>` é definido como o valor da propriedade `value`, garantindo que cada elemento tenha um `id` único e identificável.

Essas alterações visam melhorar a acessibilidade da aplicação, garantindo que os elementos tenham identificadores únicos e facilitando a associação correta entre rótulos e elementos de entrada.

Antes:
![beforeRefactSOSgif](https://github.com/SOS-RS/frontend/assets/59626996/4cd4c92a-b32a-4271-b2b1-47e00b556922)


Depois:

![afterRefactSOSgif](https://github.com/SOS-RS/frontend/assets/59626996/ddc72f5b-33e4-432c-813e-5489a25bcc2e)

