### PR TITLE
Normalizes search string in supply filter so it ignores accents

### DIFF
--- a/src/pages/EditShelterSupply/EditShelterSupply.tsx
+++ b/src/pages/EditShelterSupply/EditShelterSupply.tsx
@@ -160,6 +160,14 @@ const EditShelterSupply = () => {
             Para cada item da lista abaixo, informe a disponibilidade no abrigo
             selecionado
           </p>
+          <Button
+            variant="ghost"
+            className="flex gap-2 text-blue-500 [&_svg]:stroke-blue-500 font-medium text-lg hover:text-blue-600"
+            onClick={() => navigate(`/abrigo/${shelterId}/item/cadastrar`)}
+          >
+            <PlusCircle />
+            Cadastrar novo item
+          </Button>
           <div className="w-full my-2">
             <TextField
               label="Buscar"

--- a/src/pages/EditShelterSupply/EditShelterSupply.tsx
+++ b/src/pages/EditShelterSupply/EditShelterSupply.tsx
@@ -30,7 +30,8 @@ const EditShelterSupply = () => {
         if (v) {
           setFilteredSupplies(
             supplies.filter((s) =>
-              s.name.toLowerCase().includes(v.toLowerCase())
+              s.name.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+                .includes(v.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, ''))
             )
           );
         } else setFilteredSupplies(supplies);
@@ -159,14 +160,6 @@ const EditShelterSupply = () => {
             Para cada item da lista abaixo, informe a disponibilidade no abrigo
             selecionado
           </p>
-          <Button
-            variant="ghost"
-            className="flex gap-2 text-blue-500 [&_svg]:stroke-blue-500 font-medium text-lg hover:text-blue-600"
-            onClick={() => navigate(`/abrigo/${shelterId}/item/cadastrar`)}
-          >
-            <PlusCircle />
-            Cadastrar novo item
-          </Button>
           <div className="w-full my-2">
             <TextField
               label="Buscar"


### PR DESCRIPTION
Now, the filter misses some records because it is taking into account accents in the filter string. The following gif illustrates it.
![chrome_T6nlJvdgBD](https://github.com/SOS-RS/frontend/assets/10300609/03dbaa8c-c026-4d9e-aa3e-51b75a6e21be)

Now it normalizes the strings so it ignores the accents:
![chrome_vpUQp0De8H](https://github.com/SOS-RS/frontend/assets/10300609/d5e7f243-d619-42e3-a171-294a50f04733)
