### PR TITLE
feat: added hook to get current user geo position

### DIFF
--- a/src/hooks/useUserGeolocation/index.ts
+++ b/src/hooks/useUserGeolocation/index.ts
@@ -1,0 +1,3 @@
+import { useUserGeolocation } from './useUserGeolocation';
+
+export { useUserGeolocation };

--- a/src/hooks/useUserGeolocation/types.ts
+++ b/src/hooks/useUserGeolocation/types.ts
@@ -1,0 +1,6 @@
+export type GeoLocation =
+  | {
+      latitude: string;
+      longitude: string;
+    }
+  | undefined;

--- a/src/hooks/useUserGeolocation/useUserGeolocation.ts
+++ b/src/hooks/useUserGeolocation/useUserGeolocation.ts
@@ -1,0 +1,49 @@
+import { useCallback, useState } from 'react';
+import { GeoLocation } from './types';
+import { toast } from '@/components/ui/use-toast';
+
+const mockedUserLocation = {
+  latitude: '-30.019337370877093',
+  longitude: '-51.20618075217121',
+};
+
+const requestLocation = async (): Promise<GeoLocation> => {
+  const geolocation = navigator.geolocation;
+  if (!geolocation) return undefined;
+  return new Promise((resolve, reject) => {
+    geolocation.getCurrentPosition(
+      // successfully retrieved user location
+      (geo) => {
+        const { latitude, longitude } = geo.coords;
+        resolve({
+          latitude: latitude?.toString(),
+          longitude: longitude.toString(),
+        });
+      },
+      // user not allowed or not able to share location
+      (e) => {
+        toast({
+          title: 'Erro ao obter localização',
+          variant: 'destructive',
+        });
+        reject(e);
+      },
+      {
+        // try to use the best possible position from the device
+        enableHighAccuracy: true,
+        timeout: 50000,
+        maximumAge: 0,
+      },
+    );
+  });
+};
+
+export const useUserGeolocation = () => {
+  const [location, setLocation] = useState<GeoLocation>(undefined);
+
+  const refresh = useCallback(requestLocation, [window.navigator]);
+
+  const request = () => refresh().then(setLocation);
+
+  return { userLocation: location ?? mockedUserLocation, request };
+};


### PR DESCRIPTION
Primeiro passo para obter a lista de shelters por proximidade (ver issue #93). Esse hook facilita o acesso à API de Geolocalização do browser. É só usar o request quando o usuário clicar um botão (ou algum lifecycle) e ele já atualiza o estado interno com todas as validações, incluindo um toast caso dê erro.