### PR TITLE
[BUG] Botão de Limpar Filtro sumindo após remover input de busca

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -62,7 +62,6 @@ const Home = () => {
 
   const onSubmitFilterForm = useCallback(
     (values: IFilterFormProps) => {
-      console.log({ values });
       setOpenModal(false);
       setFilterData(values);
       const searchQuery = qs.stringify(values, {
@@ -157,12 +156,7 @@ const Home = () => {
         onFetchMoreData={handleFetchMore}
         searchValue={filterData.search}
         onSearchValueChange={(v) => {
-          console.log('antes', { filterData });
-          setFilterData((prev) => {
-            const aa = { ...prev, search: v };
-            console.log('depois', aa);
-            return aa;
-          });
+          setFilterData((prev) => ({ ...prev, search: v }));
           setSearch(v);
         }}
         hasMoreItems={hasMore}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -36,11 +36,10 @@ const Home = () => {
   const [, setSearch] = useThrottle<string>(
     {
       throttle: 400,
-      callback: (v) => {
-        const params: Record<string, string> = {
-          search: v ? qs.stringify(filterData) : '',
-        };
-        setSearchParams(params.search);
+      callback: () => {
+        const params = new URLSearchParams(qs.stringify(filterData));
+
+        setSearchParams(params);
         refresh({
           params: params,
         });
@@ -63,6 +62,7 @@ const Home = () => {
 
   const onSubmitFilterForm = useCallback(
     (values: IFilterFormProps) => {
+      console.log({ values });
       setOpenModal(false);
       setFilterData(values);
       const searchQuery = qs.stringify(values, {
@@ -157,7 +157,12 @@ const Home = () => {
         onFetchMoreData={handleFetchMore}
         searchValue={filterData.search}
         onSearchValueChange={(v) => {
-          setFilterData((prev) => ({ ...prev, search: v }));
+          console.log('antes', { filterData });
+          setFilterData((prev) => {
+            const aa = { ...prev, search: v };
+            console.log('depois', aa);
+            return aa;
+          });
           setSearch(v);
         }}
         hasMoreItems={hasMore}


### PR DESCRIPTION
- [Problema descrito no discord](https://discord.com/channels/1237553809371299950/1237555091385618523/1239785807808565268)

## Descrição

Bug no filtro botão de "Limpar filtro"  desaparecendo após remover campo de `Buscar por abrigo`

## Como replicar/reproduzir problema
1. Abra a modal de filtros e coloque um filtro
2. Aplique o filtro e escreva algum endereço no campo de busca por endereço
3. Apague o endereço e o botão "limpar filtro" irá sumir
4. Não terá como limpar o filtro, mas o filtro de dentro da modal ainda estará sendo aplicado

## Problema encontrado
- Quando o campo era esvaziado não entrava na condicional do ternário(`v` vazio) então não setava nada em params, logo atualizava com filtros vazios nos search params/query params/query string

## Solução proposta
- Setar parametros mesmo se o input de buscar abrigos vir vazio
   - A principio não precisa verificar se o novo é o mesmo do atual(antigo), porque esse callback só é chamado quando há mudanças no input 

## Pontos a salientar
Foi testado o caso base e parece ter resolvido, no QA seria bom testar exaustivamente com os vários filtros, etc