### PR TITLE
feat: added update date information to shelter page

### DIFF
--- a/src/pages/Home/components/ShelterListItem/ShelterListItem.tsx
+++ b/src/pages/Home/components/ShelterListItem/ShelterListItem.tsx
@@ -40,6 +40,8 @@ const ShelterListItem = (props: IShelterListItemProps) => {
     };
   }, []);
 
+  const updatedAtDate = data.updatedAt ? format(data.updatedAt, 'dd/MM/yyyy HH:mm') : "(sem informação)";
+
   return (
     <Link to={`/abrigo/${data.id}`} target="_blank">
       <div className="flex flex-col p-4 w-full border-2 border-border rounded-md gap-1 relative hover:bg-accent">
@@ -80,11 +82,9 @@ const ShelterListItem = (props: IShelterListItemProps) => {
             />
           </>
         )}
-        {data.updatedAt && (
-          <small className="text-sm md:text-md font-light text-muted-foreground mt-2">
-            Atualizado em {format(data.updatedAt, 'dd/MM/yyyy HH:mm')}
-          </small>
-        )}
+        <small className="text-sm md:text-md font-light text-muted-foreground mt-2">
+            Atualizado em {updatedAtDate}
+        </small>
       </div>
     </Link>
   );

--- a/src/pages/Shelter/Shelter.tsx
+++ b/src/pages/Shelter/Shelter.tsx
@@ -22,6 +22,7 @@ import { VerifiedBadge } from '@/components/VerifiedBadge/VerifiedBadge.tsx';
 import { ShelterSupplyServices } from '@/service';
 import { useToast } from '@/components/ui/use-toast';
 import { clearCache } from '@/api/cache';
+import { format } from 'date-fns';
 
 const Shelter = () => {
   const params = useParams();
@@ -53,6 +54,8 @@ const Shelter = () => {
       prev.includes(v) ? prev.filter((p) => p.value !== v.value) : [...prev, v]
     );
   }, []);
+
+  const updatedAtDate = shelter.updatedAt ? format(shelter.updatedAt, 'dd/MM/yyyy HH:mm') : "(sem informação)";
 
   const handleUpdateMany = useCallback(() => {
     setLoadingUpdateMany(true);
@@ -141,7 +144,6 @@ const Shelter = () => {
               {...categoryProps}
             />
           ))}
-        </div>
         <Authenticated role="DistributionCenter">
           <div className="flex w-full p-4">
             <Button
@@ -155,6 +157,12 @@ const Shelter = () => {
             </Button>
           </div>
         </Authenticated>
+        </div>
+        <div className="flex justify-between p-4 items-center">
+          <small className="text-sm md:text-md font-light text-muted-foreground mt-2">
+            Atualizado em {updatedAtDate}
+          </small>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Senti a falta da informação da data de atualização do abrigo dentro da página do abrigo, em vez de ser apenas no card da página principal.

Assim, adicionei a data de atualização na página do abrigo também, para melhor representar as informações quando o usuário entra no abrigo.

Um exemplo de quando um abrigo possui data de atualização:
![image](https://github.com/SOS-RS/frontend/assets/58343520/0dc094c4-5e9e-42f1-b765-408eb16ca535)

Um exemplo de quando um abrigo não possui data de atualização:
![image](https://github.com/SOS-RS/frontend/assets/58343520/d66c0283-214b-4ce4-981a-ba608e025753)

É uma mudança bem pequena, mas senti a necessidade dela ao usar o site.

Adicionalmente, informei na página inicial quando um abrigo não possui data de atualização. Assim, nesse caso, o card da página inicial fica da seguinte forma:
![image](https://github.com/SOS-RS/frontend/assets/58343520/621d550d-ee68-4a24-bfa1-d8cca2213389)

É mais um detalhe, que pode ser removido também, para evitar que tenha muita informação.
