### PR TITLE
feat: Melhoria no esquema de cores dos chip's e ajuste de acessibilidade

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -5,7 +5,7 @@ import { cva } from 'class-variance-authority';
 const Chip = React.forwardRef<HTMLDivElement, IChipProps>((props, ref) => {
   const { label, className, variant = 'info', ...rest } = props;
 
-  const variants = cva('px-4 py-1 font-normal text-sm md:text-md rounded-3xl', {
+  const variants = cva('px-4 py-1.5 font-medium text-sm md:text-md rounded-2xl', {
     variants: {
       variant: {
         warn: 'bg-light-yellow',
@@ -21,9 +21,9 @@ const Chip = React.forwardRef<HTMLDivElement, IChipProps>((props, ref) => {
   });
 
   return (
-    <div ref={ref} {...rest} className={variants({ className, variant })}>
+    <span tabIndex={0} ref={ref} {...rest} className={variants({ className, variant })}>
       {label}
-    </div>
+    </span>
   );
 });
 

--- a/src/global.css
+++ b/src/global.css
@@ -5,10 +5,10 @@
 @layer base {
   :root {
     --light-yellow: #f9cf8d;
-    --light-red: #f69f9d;
-    --light-green: #9cd487;
-    --light-orange: #f8b993;
-    --light-blue: #a2d2dc;
+    --light-red: #ffcaca;
+    --light-green: #b7eba4;
+    --light-orange: #ffcfb1;
+    --light-blue: #080909;
     --text: #2f2f2f;
 
     --background: 0 0% 100%;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -76,22 +76,22 @@ function getSupplyPriorityProps(priority: SupplyPriority) {
     case SupplyPriority.NotNeeded:
       return {
         label,
-        className: 'bg-gray-200',
+        className: 'bg-gray-200 text-gray-800',
       };
     case SupplyPriority.Remaining:
       return {
         label,
-        className: 'bg-light-green',
+        className: 'bg-light-green text-green-800',
       };
     case SupplyPriority.Needing:
       return {
         label,
-        className: 'bg-light-orange',
+        className: 'bg-light-orange text-orange-800',
       };
     case SupplyPriority.Urgent:
       return {
         label,
-        className: 'bg-light-red',
+        className: 'bg-light-red text-red-800',
       };
   }
 }


### PR DESCRIPTION
### Reprodução:
![all variants](https://github.com/SOS-RS/frontend/assets/55795035/bc06e32d-128d-43b3-8c5a-7b69422ce62a)

### Descrição
Este PR contempla uma sugestiva melhoria na exibição dos **Chip's** presente na lista de abrigos. A idéia era constrastar melhor a cor de fundo com o texto sem compremeter a acessiblidade do mesmo, trazendo uma abordagem de _soft colors_.

A alteração segue de acordo com o [WCAG 2.1 Rule 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) com uma nota de **5.15 ~ 6.5**.

Seguindo com a abordagem de acessibilidade há também um ajuste para auxiliar na navegação e para usuários que utilzam do recurso _Screen Reader_ e/ou _VoiceOver_.


https://github.com/SOS-RS/frontend/assets/55795035/79306ff7-57d3-42aa-a750-3a70ab000067

