### PR TITLE
fix: ordering the list of items on the shelter edit page

### DIFF
--- a/src/pages/EditShelterSupply/EditShelterSupply.tsx
+++ b/src/pages/EditShelterSupply/EditShelterSupply.tsx
@@ -187,7 +187,7 @@ const EditShelterSupply = () => {
                   name: v.name,
                   priority: supply?.priority,
                 };
-              });
+              }).sort((a, b) => a.name.localeCompare(b.name));
               return (
                 <SupplyRow
                   key={idx}


### PR DESCRIPTION
# Correção da listagem dos itens da página de edição de um abrigo.

### Posteriormente a listagem estava ordenada de Z - A.
<img src="https://github.com/SOS-RS/frontend/assets/82846206/42bbd1b5-149b-4ae3-9bdd-449ae557f4cd" height="600px" />

### Após a correção, temos a listagem ordenada de A - Z.
![image](https://github.com/SOS-RS/frontend/assets/82846206/a6c487dc-8e3e-4629-b67b-5c2d2b3a1f84)
