### PR TITLE
feat: add a template to log bugs/defects

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,7 +10,7 @@ assignees: ''
 Aqui você escreve sobre o que é o defeito.
 
 # Problema encontrado
-Aqui você dá detalhes sobre o problema.
+Aqui você dá detalhes sobre o problema, incluíndo os passos para reproduzir, se necessário.
 
 # Prioridade
 Registre apenas a prioridade ou seriedade do defeito. Um guia:

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Um modelo exemplo para você relatar algum defeito que tenha encontrado no site.
+title: "[BUG] Título do problema"
+labels: bug
+assignees: ''
+
+---
+# Descrição
+Aqui você escreve sobre o que é o defeito.
+
+# Problema encontrado
+Aqui você dá detalhes sobre o problema.
+
+# Prioridade
+Registre apenas a prioridade ou seriedade do defeito. Um guia:
+- Crítico: site fora do ar, erros fatas que impedem utilização por completo, página em branco
+- Grave: site online, mas com defeito sério que impedem o uso de forma considerável
+- Média: defeito não tão sério, mas que dificulta o uso da aplicação de modo geral 
+- Baixa: coisas poucas, sistema pode ser usado. Problemas de grafia são incluídos aqui
+
+# Solução proposta
+Como deveria ser o comportamento sem o defeito?
+
+# Ambiente
+Aqui você escreve o tipo de dispositivo (Modelo do celular ou sistema operacional do computador) e o navegador que utilizou para o teste.
+
+# Evidência
+Adicione o que for possível, como captura de tela ou vídeo evidenciando o problema.


### PR DESCRIPTION
Proponho a inclusão desse modelo para relatar bugs no repositório. Com o modelo, ao criar issue de bug já vira com o Markdown pronto para ser preenchido. 

O modelo segue o que já está sendo utilizado em alguns bugs aqui no repositório, com adição de algumas explicações sobre cada seção.

No futuro, podemos ter também templates para sugestões e outros tipos de issue.