### PR TITLE
fix: botao limpar filtros

### DIFF
--- a/src/pages/Home/components/ShelterListView/ShelterListView.tsx
+++ b/src/pages/Home/components/ShelterListView/ShelterListView.tsx
@@ -31,7 +31,9 @@ const ShelterListView = React.forwardRef<HTMLDivElement, IShelterListViewProps>(
       ...rest
     } = props;
 
-    const [searchParams] = useSearchParams();
+    const [searchParamsUrl] = useSearchParams();
+
+    const searchParameters = searchParamsUrl.toString().split('search=').pop();
 
     return (
       <div className={cn(className, 'flex flex-col gap-2')}>
@@ -75,7 +77,7 @@ const ShelterListView = React.forwardRef<HTMLDivElement, IShelterListViewProps>(
             <ListFilter className="h-5 w-5 stroke-blue-500" />
             Filtros
           </Button>
-          {searchParams.toString() && (
+          {searchParameters && (
             <Button
               variant="ghost"
               size="sm"


### PR DESCRIPTION
Resolve o issue #193.

Ao tirar os filtros o search parameter ficava como "search=", o que eu fiz foi pegar so os parametros depois do search para o renderizado condicional do botao.