### PR TITLE
fix: Ordena dropdown para seleção de categorias no cadastro de novo item

### DIFF
--- a/src/hooks/useSupplyCategories/useSupplyCategories.tsx
+++ b/src/hooks/useSupplyCategories/useSupplyCategories.tsx
@@ -3,10 +3,12 @@ import { PaginatedQueryPath } from '../usePaginatedQuery/paths';
 import { ISupplyCategory } from './types';
 
 const useSupplyCategories = () => {
-  return useFetch<ISupplyCategory[]>(PaginatedQueryPath.SupplyCategories, {
+  const supplyCategories = useFetch<ISupplyCategory[]>(PaginatedQueryPath.SupplyCategories, {
     initialValue: [],
     cache: true,
   });
+  supplyCategories.data.sort((a, b) => a.name.localeCompare(b.name));
+  return supplyCategories;
 };
 
 export { useSupplyCategories };

--- a/src/pages/CreateSupply/CreateSupply.tsx
+++ b/src/pages/CreateSupply/CreateSupply.tsx
@@ -132,7 +132,7 @@ const CreateSupply = () => {
                     >
                       {category.name}
                     </SelectItem>
-                  )).sort((a, b) => a.props.children.localeCompare(b.props.children))}
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/src/pages/CreateSupply/CreateSupply.tsx
+++ b/src/pages/CreateSupply/CreateSupply.tsx
@@ -132,7 +132,7 @@ const CreateSupply = () => {
                     >
                       {category.name}
                     </SelectItem>
-                  ))}
+                  )).sort((a, b) => a.props.children.localeCompare(b.props.children))}
                 </SelectContent>
               </Select>
             </div>

--- a/src/pages/Home/components/Filter/Filter.tsx
+++ b/src/pages/Home/components/Filter/Filter.tsx
@@ -216,7 +216,7 @@ const Filter = (props: IFilterProps) => {
                       label: el.name,
                       value: el.id,
                     }))
-                    .sort((a, b) => a.label.localeCompare(b.label))}
+                    }
                   onChange={(v) => setFieldValue('supplyCategories', v)}
                 />
               </div>


### PR DESCRIPTION
Ordena o dropdown no cadastro de novo item, mantendo o seu padrao nos Filtros da pagina inicial.


![Captura de tela de 2024-05-16 11-00-23](https://github.com/SOS-RS/frontend/assets/112609045/695a1005-48da-4019-bd77-4ba0d795622d)
