### PR TITLE
fix: #146 - Ajuste textual para um termo genérico para não confundir o usuário

### DIFF
--- a/src/pages/Home/components/ShelterListView/ShelterListView.tsx
+++ b/src/pages/Home/components/ShelterListView/ShelterListView.tsx
@@ -36,10 +36,10 @@ const ShelterListView = React.forwardRef<HTMLDivElement, IShelterListViewProps>(
     return (
       <div className={cn(className, 'flex flex-col gap-2')}>
         <h1 className="text-[#2f2f2f] font-semibold text-2xl">
-          Abrigos disponíveis ({count})
+          Abrigos encontrados ({count})
         </h1>
         <Alert
-          description="Você pode consultar a lista de abrigos disponíveis. Ver e editar os itens que necessitam de doações."
+          description="Você pode consultar a lista de abrigos. Ver e editar os itens que necessitam de doações."
           startAdornment={
             <CircleAlert size={20} className="stroke-light-yellow" />
           }


### PR DESCRIPTION
Correção da Issue #146 

Ajuste textual para um termo genérico para que a quantidade de abrigos retornados não seja confundido com o status "disponível". Também foi removida a palavra "disponíveis" do alerta.

Antes:
![image](https://github.com/SOS-RS/frontend/assets/14002944/f8106a46-e702-40f8-b8b6-f0a2c39c9508)

Depois: 
![image](https://github.com/SOS-RS/frontend/assets/14002944/0d691030-196a-4a16-9e54-6ca42952601f)

