### PR TITLE
fix: ordering list of cities on filter

### DIFF
--- a/src/pages/Home/components/Filter/CitiesFilter.tsx
+++ b/src/pages/Home/components/Filter/CitiesFilter.tsx
@@ -23,7 +23,7 @@ export const CitiesFilter = ({
   const options: ISelectField<string>[] = data.map((item) => ({
     label: `(${item.sheltersCount}) ${item.city}`,
     value: item.city,
-  }));
+  })).sort((a, b) => a.value.localeCompare(b.value));
 
   return (
     <div className="flex flex-col w-full gap-2">


### PR DESCRIPTION
# Correção da ordenação na listagem das cidades na filtragem de abrigos.

### Corrigindo a ordenação na listagem das cidades para ordem alfabética, visando o padrão do sistema. 
### Na imagem de exemplo temos a ordem alfabética aplicada, sem levar em conta a contagem dos abrigos.
<img src="https://github.com/SOS-RS/frontend/assets/82846206/572cdf3d-0570-4510-b829-522f6d925401" width="600px"/>
