### PR TITLE
feat:add accordion to items list on edit shelter items

### DIFF
--- a/src/pages/EditShelterSupply/EditShelterSupply.tsx
+++ b/src/pages/EditShelterSupply/EditShelterSupply.tsx
@@ -15,6 +15,7 @@ import { SupplyPriority } from '@/service/supply/types';
 import { IUseShelterDataSupply } from '@/hooks/useShelter/types';
 import { clearCache } from '@/api/cache';
 import { IUseSuppliesData } from '@/hooks/useSupplies/types';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 
 const EditShelterSupply = () => {
   const navigate = useNavigate();
@@ -185,27 +186,35 @@ const EditShelterSupply = () => {
             />
           </div>
           <div className="flex flex-col gap-2 w-full my-4">
-            {Object.entries(supplyGroups).map(([key, values], idx) => {
-              const items: ISupplyRowItemProps[] = values
-                .map((v) => {
-                  const supply = shelterSupplyData[v.id];
-                  return {
-                    id: v.id,
-                    name: v.name,
-                    quantity: supply?.quantity,
-                    priority: supply?.priority,
-                  };
-                })
-                .sort((a, b) => a.name.localeCompare(b.name));
-              return (
-                <SupplyRow
-                  key={idx}
-                  name={key}
-                  items={items}
-                  onClick={handleClickSupplyRow}
-                />
-              );
-            })}
+            <Accordion className="AccordionRoot" type="single" defaultValue="item-1" collapsible>
+              {Object.entries(supplyGroups).map(([key, values], idx) => {
+                const items: ISupplyRowItemProps[] = values
+                  .map((v) => {
+                    const supply = shelterSupplyData[v.id];
+                    return {
+                      id: v.id,
+                      name: v.name,
+                      quantity: supply?.quantity,
+                      priority: supply?.priority,
+                    };
+                  })
+                  .sort((a, b) => a.name.localeCompare(b.name));
+                return (
+                  <AccordionItem className="AccordionItem" value={key}>
+                    <AccordionTrigger>
+                      <h3 className="font-semibold text-lg">{key}</h3>
+                    </AccordionTrigger>
+                    <AccordionContent>
+                      <SupplyRow
+                        key={idx}
+                        items={items}
+                        onClick={handleClickSupplyRow}
+                      />
+                    </AccordionContent>
+                  </AccordionItem>
+                );
+              })}
+            </Accordion>
           </div>
         </div>
       </div>

--- a/src/pages/EditShelterSupply/components/SupplyRow/SupplyRow.tsx
+++ b/src/pages/EditShelterSupply/components/SupplyRow/SupplyRow.tsx
@@ -3,11 +3,10 @@ import { SupplyRowInfo } from '../SupplyRowInfo';
 import { ISupplyRowProps } from './types';
 
 const SupplyRow = (props: ISupplyRowProps) => {
-  const { name, items, onClick } = props;
+  const { items, onClick } = props;
 
   return (
     <div className="gap-4 flex flex-col pb-6">
-      <h3 className="font-semibold text-lg">{name}</h3>
       <div className="flex flex-col">
         {items.map((item, idy) => (
           <SupplyRowInfo

--- a/src/pages/EditShelterSupply/components/SupplyRow/types.ts
+++ b/src/pages/EditShelterSupply/components/SupplyRow/types.ts
@@ -8,7 +8,7 @@ export interface ISupplyRowItemProps {
 }
 
 export interface ISupplyRowProps {
-  name: string;
+  name?: string;
   onClick?: (item: ISupplyRowItemProps) => void;
   items: ISupplyRowItemProps[];
 }


### PR DESCRIPTION
# Adicionando o elemento de acordeão na listagem dos itens, na edição do abrigo.

### Visando a grande quantidade de itens já adicionados na plataforma, foi implementado este elemento de acordeão para poder expandir e minimizar as categorias.

## Exemplo da listagem antes da implementação:
<img src="https://github.com/SOS-RS/frontend/assets/82846206/34b9ae35-fe32-463e-8941-3a583863c4fc" width="600px" />

## Listagem com o elemento de acordeão:
<img src="https://github.com/SOS-RS/frontend/assets/82846206/2cb615ed-2b5a-49e0-8072-a318ea38938f" width="600px" />

### Para a implementação foi utilizado o componente já existente no projeto de accordion, vindo do diretório: ./src/components/ui/accordion.tsx