### PR TITLE
feat: Add color legend for donation items

### DIFF
--- a/src/pages/Home/components/ShelterListView/ShelterListView.tsx
+++ b/src/pages/Home/components/ShelterListView/ShelterListView.tsx
@@ -87,6 +87,25 @@ const ShelterListView = React.forwardRef<HTMLDivElement, IShelterListViewProps>(
             </Button>
           )}
         </div>
+				<div>
+					<p>
+						<strong>Legenda dos itens para doação</strong>
+					</p>
+					<ul>
+						<li className="flex gap-2 items-center">
+							<div className="w-4 h-4 rounded-md bg-light-red"></div>
+							Necessita urgente
+						</li>
+						<li className="flex gap-2 items-center">
+							<div className="w-4 h-4 rounded-md bg-light-orange"></div>
+							Precisa
+						</li>
+						<li className="flex gap-2 items-center">
+							<div className="w-4 h-4 rounded-md bg-light-green"></div>
+							Disponível para doação
+						</li>
+					</ul>
+				</div>
         <main ref={ref} className="flex flex-col gap-4" {...rest}>
           {loading ? (
             <LoadingSkeleton amountItems={4} />


### PR DESCRIPTION
Em resolução a issue #230 que sugere implementar uma seção com informações descritiva das legendas para as cores que representam os itens de doação

![image](https://github.com/SOS-RS/frontend/assets/61105850/6730599f-8c82-4393-aef8-2ce2f9d5410a)

