### PR TITLE
Adiciona a barra de scroll na vertical

### DIFF
--- a/src/components/BurgerMenu/BurgerMenu.tsx
+++ b/src/components/BurgerMenu/BurgerMenu.tsx
@@ -38,7 +38,7 @@ const BurgerMenu = () => {
         <Menu color="white" className="ml-2 mr-2" />
       </SheetTrigger>
       <SheetContent side="left" className="pt-[96px] flex flex-col">
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 overflow-y-auto">
           {session && (
             <Fragment>
               <div className="inline-flex items-center text-semibold">


### PR DESCRIPTION
## ISSUE: #235 

Quando a aplicação é aberta em celulares, e na horizontal, os itens do Sidebar não são todos exibidos, pos não existe scroll.
Foi adicionado um scroll-y que só será exibido caso a tela seja comprimida na vertical.

**Sem o scroll:**

[Gravação de tela de 17-05-2024 22:14:15.webm](https://github.com/SOS-RS/frontend/assets/50124077/f6e6aaa5-692c-4a6b-abe7-b1935eab7d06)

**Com Scroll**

[Gravação de tela de 17-05-2024 22:15:15.webm](https://github.com/SOS-RS/frontend/assets/50124077/86a246b4-3f83-493c-8e33-4952d994800e)

