### PR TITLE
Update - Melhoria na listagem de suplementos

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -5,23 +5,32 @@ import { cva } from 'class-variance-authority';
 const Chip = React.forwardRef<HTMLDivElement, IChipProps>((props, ref) => {
   const { label, className, variant = 'info', ...rest } = props;
 
-  const variants = cva('px-4 py-1.5 font-medium text-sm md:text-md rounded-2xl', {
-    variants: {
-      variant: {
-        warn: 'bg-light-yellow',
-        success: 'bg-light-green',
-        danger: 'bg-light-red',
-        alert: 'bg-light-orange',
-        info: 'bg-light-blue',
+  const variants = cva(
+    'px-4 py-1.5 font-medium text-sm md:text-md rounded-2xl',
+    {
+      variants: {
+        variant: {
+          warn: 'bg-light-yellow',
+          success: 'bg-light-green',
+          danger: 'bg-light-red',
+          alert: 'bg-light-orange',
+          info: 'bg-light-blue',
+          moreInfo: 'bg-gray-200 text-black-600',
+        },
       },
-    },
-    defaultVariants: {
-      variant: 'info',
-    },
-  });
+      defaultVariants: {
+        variant: 'info',
+      },
+    }
+  );
 
   return (
-    <span tabIndex={0} ref={ref} {...rest} className={variants({ className, variant })}>
+    <span
+      tabIndex={0}
+      ref={ref}
+      {...rest}
+      className={variants({ className, variant })}
+    >
       {label}
     </span>
   );

--- a/src/components/Chip/types.ts
+++ b/src/components/Chip/types.ts
@@ -1,4 +1,4 @@
-export type ChipVariant = 'info' | 'success' | 'warn' | 'danger';
+export type ChipVariant = 'info' | 'success' | 'warn' | 'danger' | 'moreInfo';
 
 export interface IChipProps extends React.ComponentPropsWithoutRef<'div'> {
   label: string;

--- a/src/pages/Home/components/ShelterSupplyCategoryRow/ShelterSupplyCategoryRow.tsx
+++ b/src/pages/Home/components/ShelterSupplyCategoryRow/ShelterSupplyCategoryRow.tsx
@@ -26,10 +26,7 @@ const ShelterSupplyCategoryRow = React.forwardRef<
         ))}
 
         {tags.length > 10 && (
-          <Chip
-            label={`+${tags.length - 10} items`}
-            className="bg-gray-300 txt-black-600"
-          />
+          <Chip label={`+${tags.length - 10} itens`} variant="moreInfo" />
         )}
       </div>
     </div>

--- a/src/pages/Home/components/ShelterSupplyCategoryRow/ShelterSupplyCategoryRow.tsx
+++ b/src/pages/Home/components/ShelterSupplyCategoryRow/ShelterSupplyCategoryRow.tsx
@@ -13,6 +13,10 @@ const ShelterSupplyCategoryRow = React.forwardRef<
 
   if (tags.length === 0) return <Fragment />;
 
+  const moreInfoLabel = () => {
+    return `${tags.length - 10} ${tags.length > 11 ? 'itens' : 'item'}`;
+  };
+
   return (
     <div className={cn('flex flex-col gap-3', className)} ref={ref} {...rest}>
       <Separator className="mt-2" />
@@ -26,7 +30,7 @@ const ShelterSupplyCategoryRow = React.forwardRef<
         ))}
 
         {tags.length > 10 && (
-          <Chip label={`+${tags.length - 10} itens`} variant="moreInfo" />
+          <Chip label={moreInfoLabel()} variant="moreInfo" />
         )}
       </div>
     </div>

--- a/src/pages/Home/components/ShelterSupplyCategoryRow/ShelterSupplyCategoryRow.tsx
+++ b/src/pages/Home/components/ShelterSupplyCategoryRow/ShelterSupplyCategoryRow.tsx
@@ -14,7 +14,7 @@ const ShelterSupplyCategoryRow = React.forwardRef<
   if (tags.length === 0) return <Fragment />;
 
   const moreInfoLabel = () => {
-    return `${tags.length - 10} ${tags.length > 11 ? 'itens' : 'item'}`;
+    return `+${tags.length - 10} ${tags.length > 11 ? 'itens' : 'item'}`;
   };
 
   return (

--- a/src/pages/Home/components/ShelterSupplyCategoryRow/ShelterSupplyCategoryRow.tsx
+++ b/src/pages/Home/components/ShelterSupplyCategoryRow/ShelterSupplyCategoryRow.tsx
@@ -21,9 +21,16 @@ const ShelterSupplyCategoryRow = React.forwardRef<
       </p>
       {description && <p>{description}</p>}
       <div className="flex gap-2 flex-wrap">
-        {tags.map((s, idx) => (
+        {tags.slice(0, 10).map((s, idx) => (
           <Chip key={idx} {...s} />
         ))}
+
+        {tags.length > 10 && (
+          <Chip
+            label={`+${tags.length - 10} items`}
+            className="bg-gray-300 txt-black-600"
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
 ### Melhorar a descoberta de que existem mais itens depois que o limite de 10 é excedido no card

Issue #257 
Exibindo 10 primeiros items do abrigo e décimo primeiro 'Chip' com a quantidade de items não exibidos.
PR para remoção de limite no backend: https://github.com/SOS-RS/backend/pull/136 

Screenshot da melhoria:
![Screenshot 2024-05-18 at 16 49 55](https://github.com/SOS-RS/frontend/assets/166631000/6931376b-8e89-4514-9660-803259a0df20)
