### PR TITLE
Implementar Ver Endereço no Mapa na pagina Detalhes do Abrigo

### DIFF
--- a/src/components/CardAboutShelter/CardAboutShelter.tsx
+++ b/src/components/CardAboutShelter/CardAboutShelter.tsx
@@ -1,5 +1,6 @@
 import {
   Home,
+  Map,
   UsersRound,
   HandHeart,
   PawPrint,
@@ -12,9 +13,53 @@ import {
 import { Card } from '../ui/card';
 import { ICardAboutShelter } from './types';
 import { InfoRow } from './components';
-import { checkAndFormatAddress } from './utils';
+import { checkAndFormatAddress, getGoogleMapsUrlTo } from './utils';
 import { ShelterCategory } from '@/hooks/useShelter/types';
 import { Fragment } from 'react/jsx-runtime';
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+const AddressInfoRow = (props: { shelter: ICardAboutShelter['shelter'] }) => {
+  const { shelter } = props;
+
+  const formatAddress = checkAndFormatAddress(shelter, false);
+  const googleMapsUrl = getGoogleMapsUrlTo(formatAddress);
+
+  return (
+    <>
+      <div className={cn(
+        'flex items-start gap-2 font-medium w-full',
+        'md:flex'
+      )}>
+          {React.cloneElement(<Home /> as any, {
+            className: 'min-w-5 min-h-5 w-5 h-5 stroke-muted-foreground',
+          })}
+          <div className={cn('flex flex-col gap-2 items-start', 'sm:flex-row')}>
+            <a href={googleMapsUrl} target="_blank" rel="noopener noreferrer">
+              <span className={'font-normal'}>
+                {formatAddress}
+              </span>
+            </a>
+          </div>
+      </div>
+      <div className={cn(
+        'flex items-start gap-2 font-medium w-full',
+        'md:flex'
+      )}>
+          {React.cloneElement(<Map /> as any, {
+            className: 'min-w-5 min-h-5 w-5 h-5 stroke-muted-foreground',
+          })}
+          <div className={cn('flex flex-col gap-2 items-start', 'sm:flex-row')}>
+            <a href={googleMapsUrl} target="_blank" rel="noopener noreferrer">
+              <span className={'font-normal'}>
+                <u>Ver endereço no mapa</u>
+              </span>
+            </a>
+          </div>
+      </div>
+    </>
+  );
+};
 
 const CardAboutShelter = (props: ICardAboutShelter) => {
   const { shelter } = props;
@@ -22,13 +67,12 @@ const CardAboutShelter = (props: ICardAboutShelter) => {
   const check = (v?: string | number | boolean | null) => {
     return v !== undefined && v !== null;
   };
-  const formatAddress = checkAndFormatAddress(shelter, false);
 
   return (
     <Card className="flex flex-col gap-2 p-4 bg-[#E8F0F8] text-sm">
       <div className="text-[#646870] font-medium">Sobre o abrigo</div>
       <div className="flex flex-col flex-wrap gap-3">
-        <InfoRow icon={<Home />} label={formatAddress} />
+        <AddressInfoRow shelter={shelter} />
         {Boolean(shelter.city) && (
           <InfoRow icon={<Building />} label="Cidade:" value={shelter.city} />
         )}

--- a/src/components/CardAboutShelter/utils.ts
+++ b/src/components/CardAboutShelter/utils.ts
@@ -25,4 +25,7 @@ const checkAndFormatAddress = (
   );
 };
 
-export { checkAndFormatAddress };
+const getGoogleMapsUrlTo = (address: string): string =>
+  `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`;
+
+export { checkAndFormatAddress, getGoogleMapsUrlTo };


### PR DESCRIPTION
## Sugestão de Melhoria 
- Para adicionar a navegação para o Google Maps usando o endereço fornecido direto da pagina onde mostra os detalhes do abrigo selecionado.

<img width="689" alt="Screenshot 2024-05-19 at 11 37 01" src="https://github.com/SOS-RS/frontend/assets/16091365/2604e704-bd57-497f-9ea9-b47a7f549ef2">
