### PR TITLE
remoção do link no header ao entrar nos detalhes/edição do abrigo

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -24,9 +24,15 @@ const Header = React.forwardRef<HTMLDivElement, IHeader>((props, ref) => {
     >
       <div className="flex gap-1 items-center">
         {startAdornment}
-        <Link className="font-medium text-white" to="/">
-          {title}
-        </Link>
+        {title === 'SOS Rio Grande do Sul' ? (
+          <Link className="font-medium text-white" to="/">
+            {title}
+          </Link>
+        ) : (
+          <span className="font-medium text-white">
+            {title}
+          </span>
+        )}
       </div>
       <div className="flex items-center">
         <div className="cursor-pointer ">{endAdornment}</div>


### PR DESCRIPTION
Adicionei um IF para que quando ele entrar nas informações/edições do abrigo ele remova o link que leva ate a tela inicial, porem o link da tela inicial volta ao home normalmente.

Link do teste: https://www.loom.com/share/d4d2022cfb1e4f6aa5631bc44b4e180d?sid=c0547d55-e3ec-4c7e-824c-9d5314d40709

Link da Issues: https://github.com/SOS-RS/frontend/issues/245