### PR TITLE
Filtros nao persistem ao retornar de um abrigo especifico 291

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { RotateCw } from 'lucide-react';
 import qs from 'qs';
@@ -27,6 +27,13 @@ const Home = () => {
     ...qs.parse(new URLSearchParams(window.location.search).toString()),
   });
 
+  useEffect(() => {
+    const storedSearchParams = localStorage.getItem('searchParams');
+    if (storedSearchParams) {
+      setSearchParams(new URLSearchParams(storedSearchParams));
+    }
+  }, []);
+
   const [, setSearch] = useThrottle<string>(
     {
       throttle: 400,
@@ -47,6 +54,7 @@ const Home = () => {
     setFilterData(initialFilterData);
     setSearchParams('');
     refresh();
+    localStorage.removeItem('searchParams');
   }, [refresh, setSearch, setSearchParams]);
 
   const hasMore = useMemo(
@@ -62,6 +70,7 @@ const Home = () => {
         skipNulls: true,
       });
       setSearchParams(searchQuery);
+      localStorage.setItem('searchParams', JSON.stringify(searchQuery));
       refresh({
         params: {
           search: searchQuery,

--- a/src/pages/Home/components/ShelterListView/ShelterListView.tsx
+++ b/src/pages/Home/components/ShelterListView/ShelterListView.tsx
@@ -36,7 +36,10 @@ const ShelterListView = React.forwardRef<HTMLDivElement, IShelterListViewProps>(
     return (
       <div className={cn(className, 'flex flex-col gap-2')}>
         <h1 className="text-[#2f2f2f] font-semibold text-2xl">
-          Abrigos disponíveis ({count})
+          {searchParams.toString()
+            ? `Abrigos encontrados (${count})`
+            : 'Total de abrigos'
+          }
         </h1>
         <Alert
           description="Você pode consultar a lista de abrigos disponíveis. Ver e editar os itens que necessitam de doações."

--- a/src/pages/Home/components/ShelterListView/ShelterListView.tsx
+++ b/src/pages/Home/components/ShelterListView/ShelterListView.tsx
@@ -38,7 +38,7 @@ const ShelterListView = React.forwardRef<HTMLDivElement, IShelterListViewProps>(
         <h1 className="text-[#2f2f2f] font-semibold text-2xl">
           {searchParams.toString()
             ? `Abrigos encontrados (${count})`
-            : 'Total de abrigos'
+            : `Total de abrigos  (${count})`
           }
         </h1>
         <Alert


### PR DESCRIPTION
Para que os filtros fossem persistido eu utilizei o localStorage. Veja:
```typescript
useEffect(() => {
    const storedSearchParams = localStorage.getItem('searchParams');
    if (storedSearchParams) {
      setSearchParams(new URLSearchParams(storedSearchParams));
    }
  }, []);
``` 
Nesse trecho toda vez que a página é carregada eu verifico se já existe algo salvo no localStorage com determinada chave, se houver então eu seto o setSearchParams com o valor guardado.
```typescript
const onSubmitFilterForm = useCallback(
    (values: IFilterFormProps) => {
      setOpenModal(false);
      setFilterData(values);
      const searchQuery = qs.stringify(values, {
        skipNulls: true,
      });
      setSearchParams(searchQuery);
      localStorage.setItem('searchParams', JSON.stringify(searchQuery));
      refresh({
        params: {
          search: searchQuery,
        },
      });
    },
    [refresh, setSearchParams]
  );
``` 
Quando o filtro é aplicado essa função é chamada, nela eu guardo os parametros no localStorage dessa maneira:
```typescript
localStorage.setItem('searchParams', JSON.stringify(searchQuery));
``` 
E por último quando o botão 'Limpar filtros' é executado eu limpo o valor salvo no localStorage:
```typescript
const clearSearch = useCallback(() => {
    setSearch('');
    setFilterData(initialFilterData);
    setSearchParams('');
    refresh();
    localStorage.removeItem('searchParams'); //aqui eu limpo, esse comentário não está no commit
  }, [refresh, setSearch, setSearchParams]);

  const hasMore = useMemo(
    () => shelters.page * shelters.perPage < shelters.count,
    [shelters.page, shelters.perPage, shelters.count]
  );
``` 