### PR TITLE
feat: add PetsRs link to shelter card

### DIFF
--- a/src/components/CardAboutShelter/CardAboutShelter.tsx
+++ b/src/components/CardAboutShelter/CardAboutShelter.tsx
@@ -109,7 +109,11 @@ const CardAboutShelter = (props: ICardAboutShelter) => {
       {(petsRsShelterUrl != '') ? (
           <InfoRow
             icon={<Link />}
-            label={<a target="_blank" href={petsRsShelterUrl}>Confira o abrigo em petsrs.com.br</a>}
+            label={
+              <a target="_blank" href={petsRsShelterUrl} className="font-semibold text-blue-600">
+                Confira o abrigo em petsrs.com.br
+              </a>
+            }
           />
         ) : ''}
       </div>

--- a/src/components/CardAboutShelter/CardAboutShelter.tsx
+++ b/src/components/CardAboutShelter/CardAboutShelter.tsx
@@ -7,23 +7,40 @@ import {
   Smartphone,
   Building,
   MapPinned,
+  Link,
 } from 'lucide-react';
 
 import { Card } from '../ui/card';
 import { ICardAboutShelter } from './types';
 import { InfoRow } from './components';
-import { checkAndFormatAddress } from './utils';
+import { checkAndFormatAddress, getShelterNameBeforeSeparator } from './utils';
 import { ShelterCategory } from '@/hooks/useShelter/types';
 import { Fragment } from 'react/jsx-runtime';
+import { PetsRsShelterServices } from '@/service/petsRsShelter/petsRsShelter.service';
+import { useEffect, useState } from 'react';
 
 const CardAboutShelter = (props: ICardAboutShelter) => {
   const { shelter } = props;
+  const [ petsRsShelterUrl, setPetsRsShelterUrl ] = useState('');
 
   const check = (v?: string | number | boolean | null) => {
     return v !== undefined && v !== null;
   };
-  const formatAddress = checkAndFormatAddress(shelter, false);
 
+  const getPetsRsShelterUrl = async (name: string) => {
+    const cleanShelterName = getShelterNameBeforeSeparator(name);
+    const data  = await PetsRsShelterServices.getByName(cleanShelterName);
+    const petsRsShelterUrl = data?.id ? `https://petsrs.com.br/abrigo/${data.id}` : 'https://petsrs.com.br/abrigos';
+    return petsRsShelterUrl;
+  };
+
+  useEffect(() => {
+      if(shelter.petFriendly) {
+        getPetsRsShelterUrl(shelter.name).then((url) => setPetsRsShelterUrl(url) );
+      }
+  },[shelter.petFriendly, shelter.name]);
+
+  const formatAddress = checkAndFormatAddress(shelter, false);
   return (
     <Card className="flex flex-col gap-2 p-4 bg-[#E8F0F8] text-sm">
       <div className="text-[#646870] font-medium">Sobre o abrigo</div>
@@ -89,6 +106,12 @@ const CardAboutShelter = (props: ICardAboutShelter) => {
           value={check(shelter.pix) ? `${shelter.pix}` : 'Não informado'}
           clipboardButton={check(shelter.pix)}
         />
+      {(petsRsShelterUrl != '') ? (
+          <InfoRow
+            icon={<Link />}
+            label={<a target="_blank" href={petsRsShelterUrl}>Confira o abrigo em petsrs.com.br</a>}
+          />
+        ) : ''}
       </div>
     </Card>
   );

--- a/src/components/CardAboutShelter/utils.ts
+++ b/src/components/CardAboutShelter/utils.ts
@@ -25,4 +25,15 @@ const checkAndFormatAddress = (
   );
 };
 
-export { checkAndFormatAddress };
+function getShelterNameBeforeSeparator(input: string): string {
+  const separators = ['(', '-', '[', '{'];
+  for(const separator of separators) {
+    const index = input.indexOf(separator);
+    if (index !== -1) {
+      return input.substring(0, index);
+    }
+  }
+  return input;
+}
+
+export { checkAndFormatAddress, getShelterNameBeforeSeparator };

--- a/src/components/CardAboutShelter/utils.ts
+++ b/src/components/CardAboutShelter/utils.ts
@@ -26,14 +26,7 @@ const checkAndFormatAddress = (
 };
 
 function getShelterNameBeforeSeparator(input: string): string {
-  const separators = ['(', '-', '[', '{'];
-  for(const separator of separators) {
-    const index = input.indexOf(separator);
-    if (index !== -1) {
-      return input.substring(0, index);
-    }
-  }
-  return input;
+  return input.replace(/[(\-[{].*$/, '');
 }
 
 export { checkAndFormatAddress, getShelterNameBeforeSeparator };

--- a/src/service/petsRsShelter/petsRsShelter.service.ts
+++ b/src/service/petsRsShelter/petsRsShelter.service.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+import { IPetsRsShelter } from './types';
+
+const PetsRsShelterServices = {
+  getByName: async (name: string): Promise<IPetsRsShelter> => {
+    const { data } = await axios.get(`https://cms.petsrs.com.br/api/abrigos?filters[Nome][$containsi]=${name}`);
+    return data?.data[0];
+  },
+}
+
+export { PetsRsShelterServices };

--- a/src/service/petsRsShelter/types.ts
+++ b/src/service/petsRsShelter/types.ts
@@ -1,0 +1,18 @@
+export interface Attributes {
+  Nome: string;
+  Endereco: string;
+  Longitude: string;
+  Latitude: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  Telefone: string | null;
+  nome_responsavel: string | null;
+  instagramUrl: string | null;
+  observacao: string | null;
+}
+
+export interface IPetsRsShelter {
+  id: number;
+  attributes: Attributes;
+}


### PR DESCRIPTION
**OBJETIVO DO PR**
Adição de uma nova feat. [Task aberta aqui](https://github.com/orgs/SOS-RS/projects/1?pane=issue&itemId=63437428)

**O QUE CONSTA NO PR**

- [x] Cada abrigo de pet deve ter um link visível que redirecione para a página correspondente no site Pets RS.
_Observações: não há um id mútuo entre os dois bancos (sos vs pets rs). A busca pelo abrigo correspondente na API de destino está sendo realizada utilizando o nome do abrigo da seguinte forma:_
_1. O nome do abrigo aberto pelo usuário é selecionado;_
_2. Grande parte dos abrigos possui algum separador no nome com algum comentário que não faz parte do nome. Exemplo: "Escola Estadual Infante Dom Henrique [exclusivo Pets]". Por conta disso, tudo que vier depois de separadores como (, -, [ e { será ignorado. Neste caso, a busca será feita considerando "Escola Estadual Infante Dom Henrique"._
_Há possíveis melhorias, mas esse é um start para deixar a busca pelo abrigo pet correspondente mais eficiente._
_3. Se o abrigo pet correspondente for encontrado, o link correspondente é criado. Do contrário, a url fallback será a url geral do Pets Rs._
- [x] O link deve ser claramente identificado e fácil de clicar.
- [x] O link deve abrir a página do abrigo de pets em uma nova aba.
- [x] A URL do link deve ser gerada dinamicamente com base nos dados do abrigo de pet.
- [x] Garantir que o link esteja disponível apenas para abrigos de pets.

**EVIDÊNCIAS DA ALTERAÇÃO**
![image](https://github.com/SOS-RS/frontend/assets/53581377/9cf44f58-6a1f-48a8-b535-4273547f9a97)

![image](https://github.com/SOS-RS/frontend/assets/53581377/1ec8cb86-3f77-4f42-a183-7cfc08b68509)
