### PR TITLE
[Melhoria] Mostrar filtros selecionados no popup de Filtros na tela principal

### DIFF
--- a/src/pages/Home/components/ShelterListView/ShelterListView.tsx
+++ b/src/pages/Home/components/ShelterListView/ShelterListView.tsx
@@ -8,7 +8,7 @@ import {
   ShelterListItem,
 } from '@/components';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
+import { cn, getSupplyPriorityProps } from '@/lib/utils';
 import { IShelterListViewProps } from './types';
 import { useSearchParams } from 'react-router-dom';
 import { LoadingSkeleton } from '@/components/LoadingSkeleton';
@@ -64,6 +64,18 @@ const ShelterListView = React.forwardRef<HTMLDivElement, IShelterListViewProps>(
               <span className="pr-1">{item}</span> <X className="h-4 w-4" />
             </div>
           ))}
+
+          {filterData.priority?.map((item) => (
+            <div
+              className="flex items-center px-4 py-1 font-normal text-sm md:text-md rounded-3xl bg-gray-300 justify-center cursor-pointer hover:opacity-80 transition-all duration-200"
+              key={item}
+            >
+              <span className="pr-1">{getSupplyPriorityProps(+item).label}</span> <X className="h-4 w-4" />
+            </div>
+          
+          ))}
+
+
         </div>
         <div className="flex flex-row">
           <Button


### PR DESCRIPTION
Contexto
- Hoje apenas os filtros das Cidades são mostrados na tela principal apos serem selecionados na popup de Filtros.
- Os demais da seção de Busca Avançada e Status do Abrigo, NÃO são mostrados.

Observe na imagem, a URL com os filtros selecionados, porem apenas o da Cidade é mostrado.

<img width="951" alt="Screenshot 2024-05-29 at 08 11 46" src="https://github.com/SOS-RS/frontend/assets/16091365/a4c35bf0-385c-4799-9403-f9375554f466">

