### PR TITLE
Fix/show all GitHub contributors

### DIFF
--- a/src/hooks/useGithubContributors/useGithubContributors.tsx
+++ b/src/hooks/useGithubContributors/useGithubContributors.tsx
@@ -12,7 +12,7 @@ function useGithubContributors(owner: string, repo: string) {
       setLoading(true);
       axios
         .get(
-          `https://api.github.com/repos/${owner}/${repo}/contributors`,
+          `https://api.github.com/repos/${owner}/${repo}/contributors?per_page=100`,
           config
         )
         .then(({ data }) => setData(data))

--- a/src/hooks/useGithubContributors/useGithubContributors.tsx
+++ b/src/hooks/useGithubContributors/useGithubContributors.tsx
@@ -8,15 +8,22 @@ function useGithubContributors(owner: string, repo: string) {
   const [data, setData] = useState<IGithubContributor[]>([]);
 
   const refresh = useCallback(
-    (config?: AxiosRequestConfig<any>) => {
+    async (config?: AxiosRequestConfig<any>, page=1, allData=[]) => {
       setLoading(true);
-      axios
+      const response = await axios
         .get(
-          `https://api.github.com/repos/${owner}/${repo}/contributors?per_page=100`,
+          `https://api.github.com/repos/${owner}/${repo}/contributors?per_page=100&page=${page}`,
           config
-        )
-        .then(({ data }) => setData(data))
-        .finally(() => setLoading(false));
+        );
+        const newData = allData.concat(response.data);
+        const linkHeader = response.headers.link;
+        if (linkHeader && linkHeader.includes('rel="next"')) {
+          const nextPage = page + 1;
+          return refresh(config, nextPage, newData);
+        } else {
+          setData(newData);
+          setLoading(false);
+        }
     },
     [owner, repo]
   );


### PR DESCRIPTION
Notei um pequeno problema na sessão 'Sobre nós' do site. O código que busca os contribuidores do github (tanto do back como do front) chama a api do github para buscar os contribuidores dos repositórios. O problema é que, da forma como está, a api devolve apenas os 30 contribuidores mais recentes, dado que os contribuidores ficam divididos em páginas, e o limite padrão é de 30 entradas por página. Assim, minha mudança foi pequena: primeiro eu aumentei o limite de entradas por página para 100 e então fiz um código para, se há outra página disponível, ele busca por mais contribuidores nessa página. Dessa forma, todo mundo que fez alguma contribuição irá aparecer na página, não importa quantos forem futuramente. Eu testei essa funcionalidade e parece estar funcionando normalmente, agora aparecem todos os contribuidores mesmo.

Antes:
![Captura de tela de 2024-06-22 14-38-32](https://github.com/SOS-RS/frontend/assets/58343520/dcc6b9f7-56ba-4764-a4b5-d37291b73039)

Depois:
![Captura de tela de 2024-06-22 14-38-45](https://github.com/SOS-RS/frontend/assets/58343520/12ab32aa-5fb9-43db-992e-ce617df3d6a0)
